### PR TITLE
[ Featrue ] Common TextInput 구현

### DIFF
--- a/src/app/_components/client/TextInput/TextInput.tsx
+++ b/src/app/_components/client/TextInput/TextInput.tsx
@@ -2,6 +2,8 @@
 
 import { useFormContext } from "react-hook-form";
 
+import { twMerge } from "tailwind-merge";
+
 interface TextInputProps {
   name: string;
 }
@@ -12,7 +14,10 @@ const TextInput = ({ name }: TextInputProps) => {
   return (
     <input
       type="text"
-      className="border-2 border-red-200"
+      className={twMerge(
+        "w-full h-[5.6rem] bg-example_gray_100 rounded-radius15 px-[1.2rem] text-size15",
+        "focus:outline-double focus:outline-example_gray_900 focus:outline-[0.3rem]",
+      )}
       {...register(name)}
     />
   );

--- a/src/app/_components/client/TextInput/TextInput.tsx
+++ b/src/app/_components/client/TextInput/TextInput.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+const TextInput = () => {
+  return <div>TextInput</div>;
+};
+
+export default TextInput;

--- a/src/app/_components/client/TextInput/TextInput.tsx
+++ b/src/app/_components/client/TextInput/TextInput.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-import { useFormContext } from "react-hook-form";
+import { HTMLAttributes } from "react";
+import { FieldValues, RegisterOptions, useFormContext } from "react-hook-form";
 
 import { twMerge } from "tailwind-merge";
 
-interface TextInputProps {
+interface TextInputProps extends Omit<HTMLAttributes<HTMLInputElement>, "type" | "onChange"> {
   name: string;
+  options?: RegisterOptions<FieldValues, string>;
 }
 
-const TextInput = ({ name }: TextInputProps) => {
+const TextInput = ({ name, options = {}, ...rest }: TextInputProps) => {
   const { register } = useFormContext();
 
   return (
@@ -18,7 +20,8 @@ const TextInput = ({ name }: TextInputProps) => {
         "w-full h-[5.6rem] bg-example_gray_100 rounded-radius15 px-[1.2rem] text-size15",
         "focus:outline-double focus:outline-example_gray_900 focus:outline-[0.3rem]",
       )}
-      {...register(name)}
+      {...rest}
+      {...register(name, options)}
     />
   );
 };

--- a/src/app/_components/client/TextInput/TextInput.tsx
+++ b/src/app/_components/client/TextInput/TextInput.tsx
@@ -8,19 +8,33 @@ import { twMerge } from "tailwind-merge";
 interface TextInputProps extends Omit<HTMLAttributes<HTMLInputElement>, "type" | "onChange"> {
   name: string;
   options?: RegisterOptions<FieldValues, string>;
+  placeholder?: string;
+  disabled?: boolean;
 }
 
-const TextInput = ({ name, options = {}, ...rest }: TextInputProps) => {
+const TextInput = ({
+  name,
+  options = {},
+  className,
+  placeholder,
+  disabled,
+  ...rest
+}: TextInputProps) => {
   const { register, formState } = useFormContext();
 
   return (
     <input
       type="text"
+      placeholder={placeholder}
+      disabled={disabled}
       className={twMerge(
         "w-full h-[5.6rem] bg-example_gray_100 rounded-radius15 px-[1.2rem] text-size15",
         !formState.errors[name] &&
-          "focus:outline-double focus:outline-example_gray_900 focus:outline-[0.4rem]",
-        formState.errors[name] && "outline-double outline-example_red_500 outline-[0.4rem]",
+          "focus:outline-none focus:border-example_gray_900 focus:border-[0.3rem] focus:border-double",
+        formState.errors[name] &&
+          "focus:outline-none border-double border-example_red_500 border-[0.4rem]",
+        disabled && " cursor-default opacity-40",
+        className,
       )}
       {...rest}
       {...register(name, options)}

--- a/src/app/_components/client/TextInput/TextInput.tsx
+++ b/src/app/_components/client/TextInput/TextInput.tsx
@@ -1,7 +1,21 @@
 "use client";
 
-const TextInput = () => {
-  return <div>TextInput</div>;
+import { useFormContext } from "react-hook-form";
+
+interface TextInputProps {
+  name: string;
+}
+
+const TextInput = ({ name }: TextInputProps) => {
+  const { register } = useFormContext();
+
+  return (
+    <input
+      type="text"
+      className="border-2 border-red-200"
+      {...register(name)}
+    />
+  );
 };
 
 export default TextInput;

--- a/src/app/_components/client/TextInput/TextInput.tsx
+++ b/src/app/_components/client/TextInput/TextInput.tsx
@@ -11,14 +11,16 @@ interface TextInputProps extends Omit<HTMLAttributes<HTMLInputElement>, "type" |
 }
 
 const TextInput = ({ name, options = {}, ...rest }: TextInputProps) => {
-  const { register } = useFormContext();
+  const { register, formState } = useFormContext();
 
   return (
     <input
       type="text"
       className={twMerge(
         "w-full h-[5.6rem] bg-example_gray_100 rounded-radius15 px-[1.2rem] text-size15",
-        "focus:outline-double focus:outline-example_gray_900 focus:outline-[0.3rem]",
+        !formState.errors[name] &&
+          "focus:outline-double focus:outline-example_gray_900 focus:outline-[0.4rem]",
+        formState.errors[name] && "outline-double outline-example_red_500 outline-[0.4rem]",
       )}
       {...rest}
       {...register(name, options)}

--- a/src/app/_components/client/index.ts
+++ b/src/app/_components/client/index.ts
@@ -4,4 +4,6 @@ export { default as BottomSheet } from "./BottomSheet/BottomSheet";
 export { default as Header } from "./Header/Header";
 export { default as DDuDuSheet } from "./DDuDuSheet/DDuDuSheet";
 export { default as SheetButton } from "./SheetButton/SheetButton";
+
 export { default as Button } from "./Button/Button";
+export { default as TextInput } from "./TextInput/TextInput";

--- a/src/stories/components/TextInput_Storybook/TextInput.stories.tsx
+++ b/src/stories/components/TextInput_Storybook/TextInput.stories.tsx
@@ -1,0 +1,123 @@
+import { useEffect } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+
+import { TextInput } from "@/app/_components/client";
+import type { Meta, StoryObj } from "@storybook/react";
+
+/**
+ * ## Text Input Component
+ *
+ * ### Props
+ *
+ * <br>
+ *
+ * 🔥 기본적인 Props는 Input Type을 상속받고 있습니다. 단, `type` `onChange` 제외
+ *
+ * <br>
+ *
+ * - **name : **ReactHooksForm Register에 전달될 name을 전달합니다.
+ * - **options ? : **Register의 Options 부분과 동일하게 option을 추가할 수 있습니다.
+ * - **placeholder ? : **placeholder값을 전달할 수 있습니다.
+ * - **disabled ? : **disabled 비활성화 시킬 수 있습니다.
+ *
+ * 🔥 Storybook 에서 원활한 사용을위해 FormContext 방식을 사용하였습니다.<br>
+ * ( Storybook에서는 register를 넘겨줄 수 있는 방법이 없음. )
+ *
+ * */
+const meta = {
+  title: "components/Input/TextInput",
+  component: TextInput,
+  parameters: {
+    layout: "centered",
+  },
+
+  tags: ["autodocs"],
+
+  argTypes: {
+    name: {
+      control: { disable: true },
+      description: "ReactHooksForm Register에 전달될 name을 전달합니다.",
+    },
+
+    options: {
+      control: { disable: true },
+      description: "Register의 Options 부분과 동일하게 option을 추가할 수 있습니다.",
+    },
+
+    placeholder: {
+      control: "text",
+      description: "placeholder값을 전달할 수 있습니다.",
+    },
+    disabled: {
+      control: "boolean",
+      description: "disabled 비활성화 시킬 수 있습니다.",
+    },
+  },
+
+  args: {
+    name: "",
+  },
+} satisfies Meta<typeof TextInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  decorators: [
+    (TextInputComponent, { args }) => {
+      const form = useForm({ defaultValues: { test: "" } });
+
+      return (
+        <FormProvider {...form}>
+          <TextInputComponent args={{ ...args, name: "test" }} />
+        </FormProvider>
+      );
+    },
+  ],
+};
+
+export const Error_TextInput: Story = {
+  decorators: [
+    (TextInputComponent) => {
+      const form = useForm({ defaultValues: { test: "" } });
+
+      useEffect(() => {
+        form.setError("test", { message: "Test Error" });
+      }, [form]);
+
+      return (
+        <FormProvider {...form}>
+          <TextInputComponent args={{ name: "test" }} />
+        </FormProvider>
+      );
+    },
+  ],
+};
+
+export const PlaceholderTextInput: Story = {
+  decorators: [
+    (TextInputComponent) => {
+      const form = useForm({ defaultValues: { test: "" } });
+
+      return (
+        <FormProvider {...form}>
+          <TextInputComponent args={{ name: "test", placeholder: "Placeholder Text" }} />
+        </FormProvider>
+      );
+    },
+  ],
+};
+
+export const DisabledTextInput: Story = {
+  decorators: [
+    (TextInputComponent) => {
+      const form = useForm({ defaultValues: { test: "" } });
+
+      return (
+        <FormProvider {...form}>
+          <TextInputComponent args={{ name: "test", placeholder: "Disabled", disabled: true }} />
+        </FormProvider>
+      );
+    },
+  ],
+};


### PR DESCRIPTION
## 📝 설명

Text type의 Input 구현

[🔗 Storybook](https://6633bd85fb75146bc1604a73-lvvnxaxwpy.chromatic.com/)

## ✅ PR 유형

- [x] 새로운 기능 추가

## 💻 작업 내용

Text Input을 구현하였습니다.
- Disabled 에 따라 스타일 변경
- hook Form 내부 해당하는 값에대한 Error가 존재할 경우 스타일이 변경될 수 있도록 구현
- placeholder 값 기능 추가

<br>

이번 TextInput 과 앞으로 생성될 Input은 FormProvider 방식으로 생성할 예정입니다.  <br>
해당 이유는 .. <br>

- Storybook에서 Register를 args 속성에 전달하여 사용할 수 없는 점때문에 Storybook을 생성하지 못하는점
- Error에 대한 스타일 변경을 Component 제작단계에서 일관되게 제작할 수 있는점
- 기존 Register를 모든 Component에 전달해야하는 문제 ( Props Drilling )을 개선할 수 있는점.

<br>

<br>

**사용 방법 **

1. useForm을 통해 기존과 동일하게 `Form Data`를 생성합니다.
2. Input이 들어갈 페이지 에 `FormProvider`를 씌워줍니다.
3. useForm을 통해 반환받은 변수를 그대로 `FormProvider` 태그에 풀어 넣어줍니다.

이미지 참고
![code](https://github.com/DDu-Du-DDu-Du/DDuDu_Front/assets/127748428/647e1326-a4f9-4c49-9369-aa445c4482f2)


## 💬 PR 포인트

<!-- PR 리뷰 시 공유 사항 또는 유심히 보면 좋을 부분을 설명합니다. -->
