### PR TITLE
[ Feature ] InputDate 컴포넌트 제작

### DIFF
--- a/src/app/_components/client/InputDate/InputDate.module.css
+++ b/src/app/_components/client/InputDate/InputDate.module.css
@@ -1,0 +1,31 @@
+.datePicker input[type="date"] {
+  width: 100%;
+  height: 40px;
+  text-align: left;
+  font-size: 100%;
+}
+
+.datePicker input[type="date"]::-webkit-calendar-picker-indicator {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background: transparent;
+  color: transparent;
+  cursor: pointer;
+}
+
+.datePicker input[type="date"]::before {
+  content: attr(placeholder);
+  width: 100%;
+  height: 100%;
+  line-height: 2;
+  color: gray;
+  text-align: left;
+}
+
+.datePicker input[type="date"]:focus::before,
+.datePicker input[type="date"]:valid::before {
+  display: none;
+}

--- a/src/app/_components/client/InputDate/InputDate.tsx
+++ b/src/app/_components/client/InputDate/InputDate.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import InputDateRange from "./components/InputDateRange/InputDateRange";
+import InputDateSingle from "./components/InputDateSingle/InputDateSingle";
+import getTodayFormatDate from "./utils/getTodayFormatDate";
+
+interface InputDateProps {
+  type: "single" | "range";
+  labelStart: string;
+  nameStart: string;
+  labelEnd?: string;
+  nameEnd?: string;
+}
+
+const InputDate = ({
+  type = "single",
+  labelStart,
+  nameStart,
+  labelEnd,
+  nameEnd,
+}: InputDateProps) => {
+  const todayDate = getTodayFormatDate();
+
+  return (
+    <>
+      {type === "single" && (
+        <InputDateSingle
+          label={labelStart}
+          name={nameStart}
+          todayDate={todayDate}
+        />
+      )}
+      {type === "range" && labelEnd && nameEnd && (
+        <InputDateRange
+          labelStart={labelStart}
+          nameStart={nameStart}
+          labelEnd={labelEnd}
+          nameEnd={nameEnd}
+          todayDate={todayDate}
+        />
+      )}
+    </>
+  );
+};
+
+export default InputDate;

--- a/src/app/_components/client/InputDate/components/InputDateRange/InputDateRange.tsx
+++ b/src/app/_components/client/InputDate/components/InputDateRange/InputDateRange.tsx
@@ -1,0 +1,42 @@
+import InputDateSingle from "../InputDateSingle/InputDateSingle";
+import useDateRange from "./hooks/useDateRange/useDateRange";
+
+interface InputDateRangeProps {
+  todayDate: string;
+  labelStart: string;
+  nameStart: string;
+  labelEnd: string;
+  nameEnd: string;
+}
+
+const InputDateRange = ({
+  todayDate,
+  labelStart,
+  nameStart,
+  labelEnd,
+  nameEnd,
+}: InputDateRangeProps) => {
+  const { minDate, maxDate, handleMinDateChange, handleMaxDateChange } = useDateRange({
+    todayDate,
+  });
+
+  return (
+    <div className="flex gap-[0.8rem]">
+      <InputDateSingle
+        label={labelStart}
+        name={nameStart}
+        todayDate={todayDate}
+        maxDate={maxDate}
+        onMinDateChange={handleMinDateChange}
+      />
+      <InputDateSingle
+        label={labelEnd}
+        name={nameEnd}
+        minDate={minDate}
+        onMaxDateChange={handleMaxDateChange}
+      />
+    </div>
+  );
+};
+
+export default InputDateRange;

--- a/src/app/_components/client/InputDate/components/InputDateRange/hooks/useDateRange/useDateRange.ts
+++ b/src/app/_components/client/InputDate/components/InputDateRange/hooks/useDateRange/useDateRange.ts
@@ -1,0 +1,26 @@
+import { useState } from "react";
+
+interface useDateRange {
+  todayDate: string;
+}
+
+const useDateRange = ({ todayDate }: useDateRange) => {
+  const [minDate, setMinDate] = useState(todayDate);
+  const [maxDate, setMaxDate] = useState("");
+
+  const handleMinDateChange = (date: string) => {
+    setMinDate(date);
+  };
+  const handleMaxDateChange = (date: string) => {
+    setMaxDate(date);
+  };
+
+  return {
+    minDate,
+    maxDate,
+    handleMinDateChange,
+    handleMaxDateChange,
+  };
+};
+
+export default useDateRange;

--- a/src/app/_components/client/InputDate/components/InputDateSingle/InputDateSingle.tsx
+++ b/src/app/_components/client/InputDate/components/InputDateSingle/InputDateSingle.tsx
@@ -1,0 +1,58 @@
+import styles from "../../InputDate.module.css";
+
+import { useFormContext } from "react-hook-form";
+
+import { useDateChange } from "../../hooks";
+
+interface InputDateSingleProps {
+  label: string;
+  name: string;
+  todayDate?: string;
+  minDate?: string;
+  maxDate?: string;
+  onMinDateChange?: (data: string) => void;
+  onMaxDateChange?: (data: string) => void;
+}
+
+const InputDateSingle = ({
+  label,
+  name,
+  todayDate,
+  minDate,
+  maxDate,
+  onMinDateChange,
+  onMaxDateChange,
+}: InputDateSingleProps) => {
+  const { register } = useFormContext();
+  const { date, handleInputChange } = useDateChange({
+    label,
+    onMinDateChange,
+    onMaxDateChange,
+  });
+
+  return (
+    <div className={`${styles.datePicker} relative w-[12rem]`}>
+      <div className="h-[4rem] rounded-radius10 cursor-pointer leading-[4rem] pl-[1.8rem] bg-example_gray_100">
+        <label
+          htmlFor={name}
+          className="text-size13"
+        >
+          {date}
+        </label>
+        <input
+          className="absolute top-0 left-0 w-full h-full opacity-0"
+          type="date"
+          id={name}
+          {...register(name, {
+            required: true,
+          })}
+          onChange={handleInputChange}
+          min={minDate || todayDate}
+          max={maxDate}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default InputDateSingle;

--- a/src/app/_components/client/InputDate/components/index.ts
+++ b/src/app/_components/client/InputDate/components/index.ts
@@ -1,0 +1,2 @@
+export { default as InputDateSingle } from "./InputDateSingle/InputDateSingle";
+export { default as InputDateRange } from "./InputDateRange/InputDateRange";

--- a/src/app/_components/client/InputDate/hooks/index.ts
+++ b/src/app/_components/client/InputDate/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useDateChange } from "./useDateChange/useDateChange";

--- a/src/app/_components/client/InputDate/hooks/useDateChange/useDateChange.ts
+++ b/src/app/_components/client/InputDate/hooks/useDateChange/useDateChange.ts
@@ -1,0 +1,30 @@
+import { useState } from "react";
+
+interface useDateChangeProps {
+  label: string;
+  onMinDateChange?: (date: string) => void;
+  onMaxDateChange?: (date: string) => void;
+}
+
+const useDateChange = ({ label, onMinDateChange, onMaxDateChange }: useDateChangeProps) => {
+  const [date, setDate] = useState(label);
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setDate(event.target.value);
+
+    if (onMinDateChange) {
+      onMinDateChange(event.target.value);
+    }
+
+    if (onMaxDateChange) {
+      onMaxDateChange(event.target.value);
+    }
+  };
+
+  return {
+    date,
+    handleInputChange,
+  };
+};
+
+export default useDateChange;

--- a/src/app/_components/client/InputDate/utils/getTodayFormatDate.ts
+++ b/src/app/_components/client/InputDate/utils/getTodayFormatDate.ts
@@ -1,0 +1,11 @@
+const getTodayFormatDate = () => {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = String(today.getMonth() + 1).padStart(2, "0");
+  const day = String(today.getDate()).padStart(2, "0");
+  const formattedDate = `${year}-${month}-${day}`;
+
+  return formattedDate;
+};
+
+export default getTodayFormatDate;

--- a/src/app/_components/client/index.ts
+++ b/src/app/_components/client/index.ts
@@ -14,3 +14,4 @@ export { default as Avatar } from "./Avatar/Avatar";
 export { default as Modal } from "./Modal/Modal";
 export { default as AlertModal } from "./AlertModal/AlertModal";
 export { default as ConfirmModal } from "./ConfirmModal/ConfirmModal";
+export { default as InputDate } from "./InputDate/InputDate";

--- a/src/stories/components/InputDate_Storybook/InputDate.stories.tsx
+++ b/src/stories/components/InputDate_Storybook/InputDate.stories.tsx
@@ -1,0 +1,93 @@
+import { FormProvider, useForm } from "react-hook-form";
+
+import { InputDate } from "@/app/_components/client";
+import type { Meta, StoryObj } from "@storybook/react";
+
+/**
+ * ## InputDate Component
+ *
+ * ### Props
+ * - **type :** `single`, `range` 타입을 전달 받습니다.
+ *    - **single :** 하나의 input date를 통해 날짜를 전달받습니다.
+ *    - **range :** 두 개의 input date(시작 날짜 ~ 종료 날짜) 통해 날짜를 전달받습니다. 시작 날짜의 min 값은 오늘 날짜가 되며 시작 날짜는 종료 날짜보다 클 수 없고 종료 날짜는 시작 날짜보다 작을 수 없습니다.
+ * - **labelStart :** 첫 번째 input에 대한 초기 데이터입니다. (placeholder 역할이라고 보면 됩니다.)
+ *    - 필수로 전달 받는 데이터입니다.
+ * - **nameStart :** 첫 번째 input에 대한 name 데이터입니다. 해당 데이터는 react-hook-form의 register에 전달되는 데이터입니다.
+ *   - 필수로 전달 받는 데이터입니다.
+ * - **labelEnd :** 두 번째 input에 대한 초기 데이터입니다. (placeholder 역할이라고 보면 됩니다.)
+ *    - type range인 경우에만 필수인 데이터입니다.
+ * - **nameEnd :** 두 번째 input에 대한 name 데이터입니다. 해당 데이터는 react-hook-form의 register에 전달되는 데이터입니다.
+ *   - type range인 경우에만 필수인 데이터입니다.
+ * <br>
+ *
+ * ### InputDate 사용 방법
+ *  **범위 날짜(시작 ~ 종료 날짜)가 필요한 경우**
+ *  ```
+ *  <InputDate type="range" labelStart="시작날짜" nameStart="startDate" labelEnd="종료날짜" nameEnd="endDate">
+ *  ```
+ *
+ *  <br>
+ *
+ *  **날짜 1개만 필요한 경우**<br>
+ *  ```
+ *  <InputDate type="single" labelStart="시작날짜" nameStart="startDate">
+ *  ```
+ * */
+const meta = {
+  title: "components/Input/InputDate",
+  component: InputDate,
+  parameters: {
+    layout: "centered",
+  },
+
+  tags: ["autodocs"],
+
+  argTypes: {
+    type: {
+      control: { type: "radio" },
+      description: "single, range 타입을 전달 받아 하나 혹은 두 개의 input date를 보여줍니다.",
+    },
+    labelStart: {
+      control: "text",
+      description: "첫 번째 input의 default Value가 됩니다. (placeholder 역할을 해줍니다.)",
+    },
+    nameStart: {
+      control: "text",
+      description: "첫 번째 input의 name 데이터입니다. (react-hook-form의 register name 값입니다.)",
+    },
+    labelEnd: {
+      control: "text",
+      description: "두 번째 input의 default Value가 됩니다. (placeholder 역할을 해줍니다.)",
+    },
+    nameEnd: {
+      control: "text",
+      description: "두 번째 input의 name 데이터입니다. (react-hook-form의 register name 값입니다.)",
+    },
+  },
+  args: {
+    type: "range",
+    labelStart: "시작날짜",
+    nameStart: "startDate",
+    labelEnd: "종료날짜",
+    nameEnd: "endDate",
+  },
+} satisfies Meta<typeof InputDate>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  decorators: [
+    (Story, { args }) => {
+      const methods = useForm();
+
+      return (
+        <div>
+          <FormProvider {...methods}>
+            <Story {...args} />
+          </FormProvider>
+        </div>
+      );
+    },
+  ],
+};


### PR DESCRIPTION
## 📝 설명
InputDate 컴포넌트 제작했습니다.

[스토리북 링크](https://6633bd85fb75146bc1604a73-jipmvyuznb.chromatic.com/?path=/docs/components-input-inputdate--docs)

<!-- PR에 대한 설명입니다. -->

## ✅ PR 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [x] 새로운 기능 추가
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 파일 혹은 폴더명 수정 / 삭제
- [ ] 기타

## 💻 작업 내용
**react-hook-form을 고려하여 제작**했습니다.

### getTodayFormatDate 함수 제작
- 오늘 날짜를 `0000-00-00` 형식으로 반환해주는 함수입니다.

<br/>

### InputDate 컴포넌트 제작
- **type :** `single`, `range` 타입을 받습니다. 기본값은 single입니다. type에 따라 하나, 두 개의 input date 컴포넌트를 렌더링 합니다.
     - **single :** 하나의 date 정보가 필요한 경우 사용됩니다.
    - **range :** 시작 ~ 종료와 같은 특정 범위 기간이 필요한 경우 사용됩니다. (시작 날짜의 최솟값은 오늘이며 시작 날짜는 종료 날짜보다 클 수 없습니다. 마찬가지로 종료 날짜는 시작 날짜보다 작을 수 없습니다.)
- **labelStart :** 첫 번째 input date의 default 값이 됩니다. (placeholder 역할을 해줍니다.)
   - 필수적으로 필요한 값입니다.
- **nameStart :** 첫 번째 input date의 name 프로퍼티 값으로 정의됩니다. (react-hook-form의 register 값이 됩니다.)
   - 필수적으로 필요한 값입니다.
- **labelEnd :** 두 번째 input date의 default 값이 됩니다. (placeholder 역할을 해줍니다.)
   - type이 range인 경우에만 필수 값입니다.
- **nameEnd :** 두 번째 input date의 name 프로퍼티 값으로 정의됩니다. (react-hook-form의 register 값이 됩니다.)
   - type이 range인 경우에만 필수 값입니다.
<!-- PR 본문을 입력하세요. -->

## 💬 PR 포인트

<!-- PR 리뷰 시 공유 사항 또는 유심히 보면 좋을 부분을 설명합니다. -->
