### PR TITLE
[ Feature ] FollowRequestItem 컴포넌트 제작

### DIFF
--- a/src/app/_components/client/FollowRequestItem/FollowRequestItem.tsx
+++ b/src/app/_components/client/FollowRequestItem/FollowRequestItem.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { UserType } from "@/app/_types/response/user";
+
+import { Avatar } from "../../client";
+import getTimeDiffInKorean from "./utils/getTimeDiffInKorean/getTimeDiffInKorean";
+
+interface FollowRequestItemProps {
+  user: UserType;
+  followRequestAt: string;
+  onFollowRequestCheck: (isFollow: boolean) => void;
+}
+
+const FollowRequestItem = ({
+  user,
+  followRequestAt,
+  onFollowRequestCheck,
+}: FollowRequestItemProps) => {
+  const timeAge = useMemo(() => getTimeDiffInKorean(followRequestAt), [followRequestAt]);
+
+  const handleIncompleteClick = () => {
+    console.log("거절");
+    onFollowRequestCheck(false);
+  };
+
+  const handleCompleteClick = () => {
+    console.log("수락");
+    onFollowRequestCheck(true);
+  };
+
+  return (
+    <li className="list-none">
+      <div className="flex items-center mb-[1.6rem]">
+        <Avatar user={user} />
+        <div className="flex-1 ml-[0.8rem]">
+          <span className="block text-size13 leading-[1.3rem]">
+            <b className="font-semiBold">{user.userName}님</b>이 팔로우를 요청했습니다.
+          </span>
+          <small className="text-size11 leading-[1.1rem]">{timeAge}</small>
+        </div>
+      </div>
+      <div className="flex justify-between gap-[1rem]">
+        <button
+          className="flex-1 h-[3rem] text-size11 bg-example_gray_100 rounded-radius5 hover:bg-example_gray_300 transition-colors duration-200 ease-in-out"
+          onClick={handleIncompleteClick}
+        >
+          거절
+        </button>
+        <button
+          className="flex-1 h-[3rem] text-size11 bg-example_gray_700 rounded-radius5 hover:bg-example_gray_900 transition-colors duration-200 ease-in-out"
+          onClick={handleCompleteClick}
+        >
+          수락
+        </button>
+      </div>
+    </li>
+  );
+};
+
+export default FollowRequestItem;

--- a/src/app/_components/client/FollowRequestItem/FollowRequestItem.tsx
+++ b/src/app/_components/client/FollowRequestItem/FollowRequestItem.tsx
@@ -5,7 +5,7 @@ import { useMemo } from "react";
 import { UserType } from "@/app/_types/response/user";
 
 import { Avatar } from "../../client";
-import getTimeDiffInKorean from "./utils/getTimeDiffInKorean/getTimeDiffInKorean";
+import getRelativeTime from "./utils/getRelativeTime/getRelativeTime";
 
 interface FollowRequestItemProps {
   user: UserType;
@@ -18,15 +18,13 @@ const FollowRequestItem = ({
   followRequestAt,
   onFollowRequestCheck,
 }: FollowRequestItemProps) => {
-  const timeAge = useMemo(() => getTimeDiffInKorean(followRequestAt), [followRequestAt]);
+  const timeAge = useMemo(() => getRelativeTime(followRequestAt), [followRequestAt]);
 
   const handleIncompleteClick = () => {
-    console.log("거절");
     onFollowRequestCheck(false);
   };
 
   const handleCompleteClick = () => {
-    console.log("수락");
     onFollowRequestCheck(true);
   };
 

--- a/src/app/_components/client/FollowRequestItem/utils/getRelativeTime/getRelativeTime.ts
+++ b/src/app/_components/client/FollowRequestItem/utils/getRelativeTime/getRelativeTime.ts
@@ -10,7 +10,7 @@ dayjs.extend(relativeTime);
 dayjs.locale("ko");
 dayjs.tz.setDefault("Asia/Seoul");
 
-const getTimeDiffInKorean = (utcDateString: string) => {
+const getRelativeTime = (utcDateString: string) => {
   if (!dayjs(utcDateString).isValid()) {
     throw new Error("유효하지 않은 날짜 형식입니다.");
   }
@@ -44,4 +44,4 @@ const getTimeDiffInKorean = (utcDateString: string) => {
   }
 };
 
-export default getTimeDiffInKorean;
+export default getRelativeTime;

--- a/src/app/_components/client/FollowRequestItem/utils/getTimeDiffInKorean/getTimeDiffInKorean.ts
+++ b/src/app/_components/client/FollowRequestItem/utils/getTimeDiffInKorean/getTimeDiffInKorean.ts
@@ -1,0 +1,47 @@
+import dayjs from "dayjs";
+import "dayjs/locale/ko";
+import relativeTime from "dayjs/plugin/relativeTime";
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.extend(relativeTime);
+dayjs.locale("ko");
+dayjs.tz.setDefault("Asia/Seoul");
+
+const getTimeDiffInKorean = (utcDateString: string) => {
+  if (!dayjs(utcDateString).isValid()) {
+    throw new Error("유효하지 않은 날짜 형식입니다.");
+  }
+
+  const currentTime = dayjs().tz();
+  const followRequestTime = dayjs.tz(utcDateString);
+
+  if (followRequestTime.isAfter(currentTime)) {
+    throw new Error("과거 날짜만 입력할 수 있습니다.");
+  }
+
+  const diffInSeconds = currentTime.diff(followRequestTime, "second");
+  const diffInMinutes = currentTime.diff(followRequestTime, "minute");
+  const diffInHours = currentTime.diff(followRequestTime, "hour");
+  const diffInDays = currentTime.diff(followRequestTime, "day");
+  const diffInMonths = currentTime.diff(followRequestTime, "month");
+  const diffInYears = currentTime.diff(followRequestTime, "year");
+
+  if (diffInSeconds < 60) {
+    return `${diffInSeconds}초 전`;
+  } else if (diffInMinutes < 60) {
+    return `${diffInMinutes}분 전`;
+  } else if (diffInHours < 24) {
+    return `${diffInHours}시간 전`;
+  } else if (diffInDays < 30) {
+    return `${diffInDays}일 전`;
+  } else if (diffInMonths < 12) {
+    return `${diffInMonths}개월 전`;
+  } else {
+    return `${diffInYears}년 전`;
+  }
+};
+
+export default getTimeDiffInKorean;

--- a/src/app/_components/client/index.ts
+++ b/src/app/_components/client/index.ts
@@ -17,3 +17,5 @@ export { default as ConfirmModal } from "./ConfirmModal/ConfirmModal";
 export { default as InputDate } from "./InputDate/InputDate";
 export { default as SwitchButton } from "./SwitchButton/SwitchButton";
 export { default as MonthlyGoal } from "./MonthlyGoal/MonthlyGoal";
+
+export { default as FollowRequestItem } from "./FollowRequestItem/FollowRequestItem";

--- a/src/stories/components/FollowRequestItem_Storybook/FollowRequestItem.stories.tsx
+++ b/src/stories/components/FollowRequestItem_Storybook/FollowRequestItem.stories.tsx
@@ -1,0 +1,69 @@
+import { FollowRequestItem } from "@/app/_components/client";
+import type { Meta, StoryObj } from "@storybook/react";
+
+/**
+ * ## FollowRequestItem Component
+ *
+ * ### Props
+ * - **user :** 팔로우 요청한 유저에 대한 데이터를 전달 받습니다. (userId, userName, userImage)
+ * - **followRequestAt :** 팔로우를 요청한 시간 데이터가 전달됩니다.
+ * - **onFollowRequestCheck :** 수락, 거절에 대한 응답값을 props로 전달한 함수를 통해 boolean으로 전달 받습니다.
+ *
+ * <br>
+ *
+ * ### FollowRequestItem 사용 방법
+ *
+ * ```
+ * <FollowRequestItem
+ *  user={{ userId: "코카콜라", userName: "코카콜라", userImage: null }}
+ *  followRequestAt="2024-05-24T20:06:00Z"
+ *  onFollowRequestCheck={(isFollow) => console.log(isFollow)}
+ * />
+ * ```
+ **/
+
+const meta = {
+  title: "components/FollowRequestItem",
+  component: FollowRequestItem,
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+    },
+  },
+
+  tags: ["autodocs"],
+
+  argTypes: {
+    user: {
+      control: { type: "object" },
+      of: {
+        type: "object",
+        shape: {
+          userId: { control: "text" },
+          userName: { control: "text" },
+          userImage: { control: "text" },
+        },
+      },
+      description: "userId, userName, userImage 정보를 객체로 전달받습니다.",
+    },
+    followRequestAt: {
+      control: "text",
+      description: "팔로우를 요청한 시간 데이터가 전달됩니다.",
+    },
+    onFollowRequestCheck: {
+      control: { disable: true },
+      description: "수락, 거절에 대한 응답값을 boolean으로 전달 받습니다.",
+    },
+  },
+
+  args: {
+    user: { userId: "코카콜라", userName: "코카콜라", userImage: null },
+    followRequestAt: "2024-05-24T20:06:00Z",
+    onFollowRequestCheck: () => {},
+  },
+} satisfies Meta<typeof FollowRequestItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/stories/components/FollowRequestItem_Storybook/FollowRequestItem.stories.tsx
+++ b/src/stories/components/FollowRequestItem_Storybook/FollowRequestItem.stories.tsx
@@ -5,9 +5,9 @@ import type { Meta, StoryObj } from "@storybook/react";
  * ## FollowRequestItem Component
  *
  * ### Props
- * - **user :** 팔로우 요청한 유저에 대한 데이터를 전달 받습니다. (userId, userName, userImage)
+ * - **user :** 팔로우 요청한 유저에 대한 데이터를 전달받습니다. (userId, userName, userImage)
  * - **followRequestAt :** 팔로우를 요청한 시간 데이터가 전달됩니다.
- * - **onFollowRequestCheck :** 수락, 거절에 대한 응답값을 props로 전달한 함수를 통해 boolean으로 전달 받습니다.
+ * - **onFollowRequestCheck :** 수락, 거절에 대한 응답 값을 props로 전달한 함수를 통해 boolean으로 전달받습니다.
  *
  * <br>
  *
@@ -52,7 +52,7 @@ const meta = {
     },
     onFollowRequestCheck: {
       control: { disable: true },
-      description: "수락, 거절에 대한 응답값을 boolean으로 전달 받습니다.",
+      description: "수락, 거절에 대한 응답 값을 boolean으로 전달받습니다.",
     },
   },
 


### PR DESCRIPTION
## 📝 설명

<!-- PR에 대한 설명입니다. -->
FollowRequestItem 컴포넌트 제작

[스토리북 링크](https://6633bd85fb75146bc1604a73-oirthzxelr.chromatic.com/?path=/docs/components-followrequestitem--docs)
## ✅ PR 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [x] 새로운 기능 추가
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 파일 혹은 폴더명 수정 / 삭제
- [ ] 기타

## 💻 작업 내용
### getTimeDiffInKorean 유틸 함수
```ts
const getTimeDiffInKorean = (utcDateString: string) => {}
```
- 팔로우 요청 시간을 인수로 전달받습니다.
- 전달받은 데이터가 Date 가 맞는지 검사합니다.
- 전달받은 데이터가 과거 날짜가 맞는지 검사합니다.
- 오늘 날짜 기준으로 얼마 전인지 확인하여 한국어로 반환해 줍니다. (몇 초전, 몇 분 전, 몇 시간 전, 며칠 전, 몇 달 전, 몇 년 전...)

<br/>

### FollowRequestItem 컴포넌트
- **user:** 팔로우를 요청한 user에 대한 정보를 전달받습니다. (유저 닉네임, 유저 아이디, 유저 프로필 이미지 등등)
- **followRequestAt:** 팔로우 요청한 시간을 전달받습니다. (UTC 데이터로 전달 받습니다.)
- **onFollowRequestCheck:** 팔로우를 수락, 거절 여부를 확인할 함수를 전달받습니다.
<!-- PR 본문을 입력하세요. -->

## 💬 PR 포인트
- `FollowRequestItem` 컴포넌트 내부에서 팔로우 요청에 대한 수락, 거절 시 API 처리를 해야 할지 현재처럼 props로 함수를 전달하여 수락, 거절 여부를 `boolean` 값으로 전달받고 `FollowRequestItem` 컴포넌트를 사용하는 쪽에서 처리하는 게 맞을지 고민입니다.
- 아직 `me 데이터`가 아닌 유저 정보가 어떻게 나올지 확정되지 않아 임의로 `UserType`을 만들었습니다. (추후 Avatar 등등 UserType은 변경이 필요합니다.)


<!-- PR 리뷰 시 공유 사항 또는 유심히 보면 좋을 부분을 설명합니다. -->
