### PR TITLE
[Fix] 반복 뚜두 수정 페이지 오류

### DIFF
--- a/src/app/(route)/goal/editor/[id]/repeat/components/DDuDuRepeatEditor/hooks/useRepeatEditor/useRepeatEditor.ts
+++ b/src/app/(route)/goal/editor/[id]/repeat/components/DDuDuRepeatEditor/hooks/useRepeatEditor/useRepeatEditor.ts
@@ -16,6 +16,8 @@ const useRepeatEditor = ({ repeatId }: UseRepeatEditorProps) => {
     return repeatDDuDu.filter((ddudu) => String(ddudu.id) === repeatId)[0];
   }, [repeatDDuDu, repeatId]);
 
+  console.log("currentRepeatDDuDu", currentRepeatDDuDu);
+
   const currentRepeatMonthData =
     currentRepeatDDuDu && currentRepeatDDuDu.repeatPattern.repeatType === "MONTHLY"
       ? (currentRepeatDDuDu.repeatPattern.repeatDaysOfMonth?.map(String) as DayOfMonthString[])

--- a/src/app/(route)/goal/editor/[id]/repeats/components/DDuDuRepeatList/DDuDuRepeatList.tsx
+++ b/src/app/(route)/goal/editor/[id]/repeats/components/DDuDuRepeatList/DDuDuRepeatList.tsx
@@ -33,6 +33,7 @@ const DDuDuRepeatList = ({ goalId }: DDuDuRepeatListProps) => {
                 startDate={startDate}
                 endDate={endDate}
                 goalId={goalId}
+                bgColor="#FFFFFF"
               />
             </Fragment>
           ))}

--- a/src/app/_components/server/GoalTodoListItem/GoalTodoListItem.tsx
+++ b/src/app/_components/server/GoalTodoListItem/GoalTodoListItem.tsx
@@ -10,6 +10,7 @@ export interface GoalTodoListItemProps {
   startDate: string;
   endDate: string;
   goalId?: string;
+  bgColor?: string;
 }
 
 const GoalTodoListItem = ({
@@ -19,11 +20,13 @@ const GoalTodoListItem = ({
   startDate,
   endDate,
   goalId,
+  bgColor = "#F5F5F5",
 }: GoalTodoListItemProps) => {
   return (
     <li className="list-none font-regular">
       <Link
-        className="block rounded-radius10 bg-white_100 px-[1.8rem] py-[1.2rem]"
+        className="block rounded-radius10 px-[1.8rem] py-[1.2rem]"
+        style={{ backgroundColor: bgColor }}
         href={
           goalId ? `/goal/editor/${goalId}/repeat?id=${id}` : `/goal/editor/create/repeat?id=${id}`
         }


### PR DESCRIPTION
## 📝 설명
- 목표 생성 시 생성한 반복 뚜두를 수정 및 삭제하려고 하는 경우 기존 데이터가 나오지 않는 문제
- 목표를 생성한 후 생성된 반복 뚜두를 수정 및 삭제하려고 하는 경우 수정 데이터가 아닌 생성 데이터가 나오는 문제
<!-- PR에 대한 설명입니다. -->

## ✅ PR 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [ ] 새로운 기능 추가
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 파일 혹은 폴더명 수정 / 삭제
- [x] 기타

## 💻 작업 내용
 - 목표 생성 시 함께 생성한 반복 뚜두를 수정 및 삭제할 수 있도록 로직 개선
 - 목표를 생성한 후 반복 관리 페이지에서 생성된 반복 뚜두를 수정 및 삭제할 수 있도록 로직 개선
<!-- PR 본문을 입력하세요. -->
