### PR TITLE
[Refactor] 반복 뚜두 페이지 개선

### DIFF
--- a/src/app/(route)/goal/editor/[id]/repeat/components/DDuDuRepeatEditor/DDuDuRepeatEditor.tsx
+++ b/src/app/(route)/goal/editor/[id]/repeat/components/DDuDuRepeatEditor/DDuDuRepeatEditor.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useGoalDetail } from "@/app/_hooks";
+
 import DDuDuRepeatForm from "../DDuDuRepeatForm/DDuDuRepeatForm";
 import useRepeatEditor from "./hooks/useRepeatEditor/useRepeatEditor";
 
@@ -9,7 +11,13 @@ interface DDuDuRepeatEditorProps {
 }
 
 const DDuDuRepeatEditor = ({ goalId, repeatId }: DDuDuRepeatEditorProps) => {
-  const { currentRepeatDDuDu, currentRepeatMonthData } = useRepeatEditor({ repeatId });
+  console.log("DDuDuRepeatEditor의 repeatId", repeatId);
+
+  const { goalDetail } = useGoalDetail({ goalId });
+  const { currentRepeatDDuDu, currentRepeatMonthData } = useRepeatEditor({
+    repeatId,
+    repeatDDuDu: goalDetail?.repeatDdudus,
+  });
 
   if (repeatId && !currentRepeatDDuDu) {
     return null;

--- a/src/app/(route)/goal/editor/[id]/repeat/components/DDuDuRepeatEditor/hooks/useRepeatEditor/useRepeatEditor.ts
+++ b/src/app/(route)/goal/editor/[id]/repeat/components/DDuDuRepeatEditor/hooks/useRepeatEditor/useRepeatEditor.ts
@@ -1,19 +1,15 @@
 import { useMemo } from "react";
 
-import { useGoalFormStore } from "@/app/_store";
 import { RepeatDdudusType } from "@/app/_types/response/goal/goal";
 
 import { DayOfMonthString } from "../../../DDuDuRepeatForm/DDuDuRepeatForm.types";
 
 interface UseRepeatEditorProps {
   repeatId: string;
+  repeatDDuDu?: RepeatDdudusType[];
 }
 
-const useRepeatEditor = ({ repeatId }: UseRepeatEditorProps) => {
-  const { repeatDDuDu } = useGoalFormStore();
-
-  console.log("repeatDDuDu", repeatDDuDu);
-
+const useRepeatEditor = ({ repeatId, repeatDDuDu = [] }: UseRepeatEditorProps) => {
   const currentRepeatDDuDu: RepeatDdudusType = useMemo(() => {
     return repeatDDuDu.filter((ddudu) => String(ddudu.id) === repeatId)[0];
   }, [repeatDDuDu, repeatId]);

--- a/src/app/(route)/goal/editor/[id]/repeat/page.tsx
+++ b/src/app/(route)/goal/editor/[id]/repeat/page.tsx
@@ -11,7 +11,8 @@ const GoalEditorDDuDuRepeatPage = ({ params, searchParams }: GoalEditorDDuDuRepe
   const { id: goalId } = params;
   const { id: repeatId } = searchParams;
 
-  console.log("repeatId", repeatId);
+  console.log("params goalId", goalId);
+  console.log("searchParams repeatId", repeatId);
 
   return (
     <section>

--- a/src/app/(route)/goal/editor/[id]/repeats/components/DDuDuRepeatList/DDuDuRepeatList.tsx
+++ b/src/app/(route)/goal/editor/[id]/repeats/components/DDuDuRepeatList/DDuDuRepeatList.tsx
@@ -3,7 +3,7 @@
 import { Fragment } from "react";
 
 import { GoalTodoListItem } from "@/app/_components/server";
-import { useGoalFormStore } from "@/app/_store";
+import { useGoalDetail } from "@/app/_hooks";
 
 import { DAY_OF_WEEK_STRING } from "../../../repeat/components/DDuDuRepeatForm/DDuDuRepeatForm.constants";
 
@@ -12,7 +12,13 @@ interface DDuDuRepeatListProps {
 }
 
 const DDuDuRepeatList = ({ goalId }: DDuDuRepeatListProps) => {
-  const { repeatDDuDu } = useGoalFormStore();
+  const { goalDetail } = useGoalDetail({ goalId });
+
+  if (!goalDetail) {
+    return;
+  }
+
+  const { repeatDdudus: repeatDDuDu } = goalDetail;
 
   return (
     <>

--- a/src/app/_hooks/index.ts
+++ b/src/app/_hooks/index.ts
@@ -1,2 +1,3 @@
 export { default as useClickAway } from "./useClickAway/useClickAway";
 export { default as useToggle } from "./useToggle/useToggle";
+export { default as useGoalDetail } from "./useGoalDetail/useGoalDetail";

--- a/src/app/_hooks/useGoalDetail/useGoalDetail.ts
+++ b/src/app/_hooks/useGoalDetail/useGoalDetail.ts
@@ -1,0 +1,25 @@
+import { GOAL_KEY } from "@/app/_constants/queryKey/queryKey";
+import { getGoalEditorData } from "@/app/_services/client/goalEditor";
+import { GoalDetailType } from "@/app/_types/response/goal/goal";
+import { useQuery } from "@tanstack/react-query";
+
+import { useSession } from "next-auth/react";
+
+interface UseGoalDetailProps {
+  goalId: string;
+}
+
+const useGoalDetail = ({ goalId }: UseGoalDetailProps) => {
+  const { data: session } = useSession();
+
+  const { data: goalDetail } = useQuery<GoalDetailType>({
+    queryKey: [GOAL_KEY.GOAL_EDITOR, goalId],
+    queryFn: () => getGoalEditorData(session?.sessionToken as string, goalId),
+  });
+
+  return {
+    goalDetail,
+  };
+};
+
+export default useGoalDetail;


### PR DESCRIPTION
## 📝 설명
- 기존 `goal/editor`에 접근하는 경우 데이터 패칭을 통해 데이터를 전역 스토어에 저장하고 저장된 데이터를 가져다 쓰는 방식이었습니다.
- 현재는 캐싱된 `Query 값`을 호출하여 페이지에서 데이터를 호출하여 사용하도록 수정했습니다.
<!-- PR에 대한 설명입니다. -->

## ✅ PR 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [ ] 새로운 기능 추가
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 파일 혹은 폴더명 수정 / 삭제
- [x] 기타