### PR TITLE
[Feature] 반복 뚜두 삭제 기능 추가

### DIFF
--- a/src/app/(route)/goal/editor/[id]/repeat/components/DDuDuRepeatEditor/DDuDuRepeatEditor.tsx
+++ b/src/app/(route)/goal/editor/[id]/repeat/components/DDuDuRepeatEditor/DDuDuRepeatEditor.tsx
@@ -17,6 +17,7 @@ const DDuDuRepeatEditor = ({ goalId }: DDuDuRepeatEditorProps) => {
 
   const { currentRepeatDDuDu, currentRepeatMonthData } = useRepeatEditor({
     repeatId,
+    goalId,
   });
 
   if (repeatId && !currentRepeatDDuDu) {

--- a/src/app/(route)/goal/editor/[id]/repeat/components/DDuDuRepeatEditor/hooks/useRepeatEditor/useRepeatEditor.ts
+++ b/src/app/(route)/goal/editor/[id]/repeat/components/DDuDuRepeatEditor/hooks/useRepeatEditor/useRepeatEditor.ts
@@ -1,20 +1,25 @@
 import { useMemo } from "react";
 
-import { useGoalFormStore } from "@/app/_store";
+import { useGoalDetail } from "@/app/_hooks";
 import { RepeatDdudusType } from "@/app/_types/response/goal/goal";
 
 import { DayOfMonthString } from "../../../DDuDuRepeatForm/DDuDuRepeatForm.types";
 
 interface UseRepeatEditorProps {
   repeatId: string;
+  goalId: string;
 }
 
-const useRepeatEditor = ({ repeatId }: UseRepeatEditorProps) => {
-  const { repeatDDuDu } = useGoalFormStore();
+const useRepeatEditor = ({ repeatId, goalId }: UseRepeatEditorProps) => {
+  const { goalDetail } = useGoalDetail({ goalId });
 
-  const currentRepeatDDuDu: RepeatDdudusType = useMemo(() => {
-    return repeatDDuDu.filter((ddudu) => String(ddudu.id) === repeatId)[0];
-  }, [repeatDDuDu, repeatId]);
+  const currentRepeatDDuDu: RepeatDdudusType | undefined = useMemo(() => {
+    if (!goalDetail) return;
+
+    const { repeatDdudus } = goalDetail;
+
+    return repeatDdudus.filter((ddudu) => String(ddudu.id) === repeatId)[0];
+  }, [goalDetail, repeatId]);
 
   const currentRepeatMonthData =
     currentRepeatDDuDu && currentRepeatDDuDu.repeatPattern.repeatType === "MONTHLY"

--- a/src/app/(route)/goal/editor/[id]/repeat/components/DDuDuRepeatForm/DDuDuRepeatForm.tsx
+++ b/src/app/(route)/goal/editor/[id]/repeat/components/DDuDuRepeatForm/DDuDuRepeatForm.tsx
@@ -175,6 +175,7 @@ const DDuDuRepeatForm = ({
             <li>
               <button
                 className="w-full h-[4rem] text-size13 font-medium bg-example_gray_100 rounded-radius10 text-red_500"
+                type="button"
                 onClick={handleRepeatDDuDuDelete}
               >
                 반복 삭제하기

--- a/src/app/(route)/goal/editor/[id]/repeat/components/DDuDuRepeatForm/hooks/useDeleteRepeatDDuDuMutation/useDeleteRepeatDDuDuMutation.ts
+++ b/src/app/(route)/goal/editor/[id]/repeat/components/DDuDuRepeatForm/hooks/useDeleteRepeatDDuDuMutation/useDeleteRepeatDDuDuMutation.ts
@@ -1,5 +1,9 @@
+import { FEED_KEY, GOAL_KEY, REPEAT_DDUDU_KEY } from "@/app/_constants/queryKey/queryKey";
+import { fetchDeleteRepeatDDudu } from "@/app/_services/client/repeatDdudu";
 import { RepeatDdudusType } from "@/app/_types/response/goal/goal";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
+import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 
 interface UseDeleteRepeatDDuDuMutationProps {
@@ -17,13 +21,32 @@ const useDeleteRepeatDDuDuMutation = ({
 }: UseDeleteRepeatDDuDuMutationProps) => {
   const router = useRouter();
 
+  const { data: session } = useSession();
+  const queryClient = useQueryClient();
+
+  const deleteRepeatDDuDuMutation = useMutation({
+    mutationKey: [REPEAT_DDUDU_KEY.REPEAT_DELETE],
+    mutationFn: fetchDeleteRepeatDDudu,
+    onSuccess: () => {
+      router.back();
+      queryClient.invalidateQueries({ queryKey: [GOAL_KEY.GOAL_EDITOR, goalId] });
+      queryClient.invalidateQueries({ queryKey: [FEED_KEY.MONTHLY_DDUDUS] });
+      queryClient.invalidateQueries({ queryKey: [FEED_KEY.DAILY_LIST] });
+      queryClient.invalidateQueries({ queryKey: [FEED_KEY.WEEKLY_DDUDUS] });
+      queryClient.invalidateQueries({ queryKey: [FEED_KEY.DAILY_TIMETABLE] });
+    },
+  });
+
   const handleRepeatDDuDuDelete = () => {
     if (goalId === "create") {
       const updateRepeatDDuDu = repeatDDuDu.filter((ddudu) => ddudu.id !== Number(repeatId));
       setRepeatDDuDu(updateRepeatDDuDu);
-      router.replace("/goal/editor");
+      router.back();
     } else {
-      // repeatDDuDu DELETE API호출
+      deleteRepeatDDuDuMutation.mutate({
+        accessToken: session?.sessionToken as string,
+        repeatId,
+      });
     }
   };
 

--- a/src/app/(route)/goal/editor/[id]/repeat/components/DDuDuRepeatForm/hooks/useRepeatDDuDuMutation/useRepeatDDuDuMutation.ts
+++ b/src/app/(route)/goal/editor/[id]/repeat/components/DDuDuRepeatForm/hooks/useRepeatDDuDuMutation/useRepeatDDuDuMutation.ts
@@ -1,10 +1,10 @@
 import { SubmitHandler } from "react-hook-form";
 
-import { REPEAT_DDUDU_KEY } from "@/app/_constants/queryKey/queryKey";
+import { FEED_KEY, GOAL_KEY, REPEAT_DDUDU_KEY } from "@/app/_constants/queryKey/queryKey";
 import { fetchCreateRepeatDDudu, fetchEditRepeatDDudu } from "@/app/_services/client/repeatDdudu";
 import { RepeatDduduRequestType } from "@/app/_types/request/repeatDdudu/repeatDdudu";
 import { DayOfMonth, RepeatDdudusPattern, RepeatDdudusType } from "@/app/_types/response/goal/goal";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { DDuDuRepeatFormDataType } from "../../DDuDuRepeatForm";
 
@@ -29,21 +29,27 @@ const useRepeatDDuDuMutation = ({
   const router = useRouter();
 
   const { data: session } = useSession();
+  const queryClient = useQueryClient();
+
+  const handleDDuDuMutationSuccess = () => {
+    queryClient.invalidateQueries({ queryKey: [GOAL_KEY.GOAL_EDITOR, goalId] });
+    queryClient.invalidateQueries({ queryKey: [FEED_KEY.MONTHLY_DDUDUS] });
+    queryClient.invalidateQueries({ queryKey: [FEED_KEY.DAILY_LIST] });
+    queryClient.invalidateQueries({ queryKey: [FEED_KEY.WEEKLY_DDUDUS] });
+    queryClient.invalidateQueries({ queryKey: [FEED_KEY.DAILY_TIMETABLE] });
+    router.back();
+  };
 
   const createRepeatDDuDuMutation = useMutation({
     mutationKey: [REPEAT_DDUDU_KEY.REPEAT_DDUDU],
     mutationFn: fetchCreateRepeatDDudu,
-    onSuccess: () => {
-      router.replace(`/goal/editor/${goalId}/repeats`);
-    },
+    onSuccess: handleDDuDuMutationSuccess,
   });
 
   const editRepeatDDuDuMutation = useMutation({
     mutationKey: [REPEAT_DDUDU_KEY.REPEAT_DDUDU, repeatId],
     mutationFn: fetchEditRepeatDDudu,
-    onSuccess: () => {
-      router.replace(`/goal/editor/${goalId}/repeats`);
-    },
+    onSuccess: handleDDuDuMutationSuccess,
   });
 
   const onValid: SubmitHandler<DDuDuRepeatFormDataType> = ({

--- a/src/app/(route)/goal/editor/components/GoalEditor/GoalEditor.tsx
+++ b/src/app/(route)/goal/editor/components/GoalEditor/GoalEditor.tsx
@@ -1,29 +1,17 @@
 "use client";
 
 import { ConfirmModal } from "@/app/_components/client";
-import { GOAL_KEY } from "@/app/_constants/queryKey/queryKey";
-import { useToggle } from "@/app/_hooks";
-import { getGoalEditorData } from "@/app/_services/client/goalEditor";
-import { GoalDetailType } from "@/app/_types/response/goal/goal";
-import { useQuery } from "@tanstack/react-query";
+import { useGoalDetail, useToggle } from "@/app/_hooks";
 
 import { GoalEditorForm } from "./components";
 import { useTempData } from "./hooks";
-
-import { useSession } from "next-auth/react";
 
 interface GoalEditorProps {
   goalId: string;
 }
 
 const GoalEditor = ({ goalId }: GoalEditorProps) => {
-  const { data: session } = useSession();
-
-  const { data: goalEditorData } = useQuery<GoalDetailType>({
-    queryKey: [GOAL_KEY.GOAL_EDITOR, goalId],
-    queryFn: () => getGoalEditorData(session?.sessionToken as string, goalId),
-    enabled: !!goalId && !!session,
-  });
+  const { goalDetail: goalEditorData } = useGoalDetail({ goalId });
 
   const { isToggle: isModal, handleToggleOn: openModal, handleToggleOff: closeModal } = useToggle();
 

--- a/src/app/(route)/goal/editor/components/GoalEditor/components/GoalEditorForm/hooks/useDeleteGoalMutation/useDeleteGoalMutation.ts
+++ b/src/app/(route)/goal/editor/components/GoalEditor/components/GoalEditorForm/hooks/useDeleteGoalMutation/useDeleteGoalMutation.ts
@@ -21,8 +21,10 @@ const useDeleteGoal = ({ sessionToken, goalId, reset }: UseDeleteGoalProps) => {
       queryClient.invalidateQueries({ queryKey: [GOAL_KEY.GOAL_LIST] });
       queryClient.invalidateQueries({ queryKey: [FEED_KEY.DAILY_TIMETABLE] });
       queryClient.invalidateQueries({ queryKey: [FEED_KEY.DAILY_LIST] });
+      queryClient.invalidateQueries({ queryKey: [FEED_KEY.MONTHLY_DDUDUS] });
+      queryClient.invalidateQueries({ queryKey: [FEED_KEY.WEEKLY_DDUDUS] });
       reset();
-      router.replace("/goal");
+      router.back();
     },
   });
 

--- a/src/app/(route)/goal/editor/components/GoalEditor/components/GoalEditorForm/hooks/useStatusChangeGoalMutation/useStatusChangeGoalMutation.ts
+++ b/src/app/(route)/goal/editor/components/GoalEditor/components/GoalEditorForm/hooks/useStatusChangeGoalMutation/useStatusChangeGoalMutation.ts
@@ -28,8 +28,10 @@ const useStatusChangeGoalMutation = ({
       queryClient.invalidateQueries({ queryKey: [GOAL_KEY.GOAL_LIST] });
       queryClient.invalidateQueries({ queryKey: [FEED_KEY.DAILY_TIMETABLE] });
       queryClient.invalidateQueries({ queryKey: [FEED_KEY.DAILY_LIST] });
+      queryClient.invalidateQueries({ queryKey: [FEED_KEY.MONTHLY_DDUDUS] });
+      queryClient.invalidateQueries({ queryKey: [FEED_KEY.WEEKLY_DDUDUS] });
+      router.back();
       reset();
-      router.replace("/goal");
     },
   });
 

--- a/src/app/(route)/goal/editor/components/GoalEditor/components/GoalEditorForm/hooks/useUpdateGoalMutation/useUpdateGoalMutation.ts
+++ b/src/app/(route)/goal/editor/components/GoalEditor/components/GoalEditorForm/hooks/useUpdateGoalMutation/useUpdateGoalMutation.ts
@@ -29,15 +29,21 @@ const useUpdateGoalMutation = ({
   const router = useRouter();
   const queryClient = useQueryClient();
 
+  const handleGoalMutationSuccess = () => {
+    queryClient.invalidateQueries({ queryKey: [GOAL_KEY.GOAL_LIST] });
+    queryClient.invalidateQueries({ queryKey: [FEED_KEY.DAILY_TIMETABLE] });
+    queryClient.invalidateQueries({ queryKey: [FEED_KEY.DAILY_LIST] });
+    router.back();
+    reset();
+  };
+
   const createGoalMutation = useMutation({
     mutationKey: [GOAL_KEY.GOAL_CREATE],
     mutationFn: fetchCreateGoal,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [GOAL_KEY.GOAL_LIST] });
-      queryClient.invalidateQueries({ queryKey: [FEED_KEY.DAILY_TIMETABLE] });
-      queryClient.invalidateQueries({ queryKey: [FEED_KEY.DAILY_LIST] });
-      reset();
-      router.replace("/goal");
+      queryClient.invalidateQueries({ queryKey: [FEED_KEY.MONTHLY_DDUDUS] });
+      queryClient.invalidateQueries({ queryKey: [FEED_KEY.WEEKLY_DDUDUS] });
+      handleGoalMutationSuccess();
     },
   });
 
@@ -46,11 +52,7 @@ const useUpdateGoalMutation = ({
     mutationFn: fetchEditGoal,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [GOAL_KEY.GOAL_EDITOR, goalId] });
-      queryClient.invalidateQueries({ queryKey: [GOAL_KEY.GOAL_LIST] });
-      queryClient.invalidateQueries({ queryKey: [FEED_KEY.DAILY_TIMETABLE] });
-      queryClient.invalidateQueries({ queryKey: [FEED_KEY.DAILY_LIST] });
-      reset();
-      router.replace("/goal");
+      handleGoalMutationSuccess();
     },
   });
 
@@ -77,6 +79,11 @@ const useUpdateGoalMutation = ({
         } else if (ddudu.repeatPattern.repeatType === "MONTHLY") {
           repeatDDuDu.repeatDaysOfMonth = ddudu.repeatPattern.repeatDaysOfMonth;
           repeatDDuDu.lastDayOfMonth = ddudu.repeatPattern.lastDay;
+        }
+
+        if (ddudu.beginAt && ddudu.endAt) {
+          repeatDDuDu.beginAt = ddudu.beginAt;
+          repeatDDuDu.endAt = ddudu.endAt;
         }
 
         return repeatDDuDu;

--- a/src/app/_components/server/GoalItem/components/GoalManagement/GoalManagement.tsx
+++ b/src/app/_components/server/GoalItem/components/GoalManagement/GoalManagement.tsx
@@ -32,7 +32,7 @@ const GoalManagement = ({
       {...draggableProps}
     >
       <span
-        className="mr-[1rem] py-[0.5rem]"
+        className="mr-[1rem] py-[1rem]"
         {...dragHandleProps}
       >
         <DragIcon />

--- a/src/app/_constants/endPoint/repeatDdudu/repeatDdudu.ts
+++ b/src/app/_constants/endPoint/repeatDdudu/repeatDdudu.ts
@@ -1,6 +1,7 @@
 const REPEAT_DDUDU = {
   CREATE: "/api/repeat-ddudus",
   EDIT: "/api/repeat-ddudus",
+  DELETE: "/api/repeat-ddudus",
 };
 
 export default REPEAT_DDUDU;

--- a/src/app/_constants/queryKey/queryKey.ts
+++ b/src/app/_constants/queryKey/queryKey.ts
@@ -31,4 +31,5 @@ export const GOAL_KEY = {
 
 export const REPEAT_DDUDU_KEY = {
   REPEAT_DDUDU: "repeatDdudu",
+  REPEAT_DELETE: "repeatDelete",
 };

--- a/src/app/_hooks/useGoalDetail/useGoalDetail.ts
+++ b/src/app/_hooks/useGoalDetail/useGoalDetail.ts
@@ -15,6 +15,7 @@ const useGoalDetail = ({ goalId }: UseGoalDetailProps) => {
   const { data: goalDetail } = useQuery<GoalDetailType>({
     queryKey: [GOAL_KEY.GOAL_EDITOR, goalId],
     queryFn: () => getGoalEditorData(session?.sessionToken as string, goalId),
+    enabled: !!goalId && !!session,
   });
 
   return {

--- a/src/app/_services/client/repeatDdudu.ts
+++ b/src/app/_services/client/repeatDdudu.ts
@@ -60,3 +60,28 @@ export const fetchEditRepeatDDudu = async ({
 
   return response.json();
 };
+
+interface FetchDeleteRepeatDDuduProps {
+  accessToken: string;
+  repeatId: string;
+}
+
+export const fetchDeleteRepeatDDudu = async ({
+  accessToken,
+  repeatId,
+}: FetchDeleteRepeatDDuduProps) => {
+  const response = await fetchApi(`${REPEAT_DDUDU.DELETE}/${repeatId}`, {
+    method: "DELETE",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+  if (response.status === 204) {
+    return;
+  }
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+  return response.json();
+};


### PR DESCRIPTION
## 📝 설명
#74 

**repeatDDuDU 삭제 기능 추가**
<!-- PR에 대한 설명입니다. -->

## ✅ PR 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [x] 새로운 기능 추가
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드 리팩토링
- [ ] 파일 혹은 폴더명 수정 / 삭제
- [ ] 기타

## 💻 작업 내용
- 목표 관리 드래그 아이콘 드래그 영역 범위 수정
- 목표 생성 후 반복 관리 페이지에서 반복되는 투두 리스트를 삭제하는 기능 추가하기
  - `form` 태그 안에 존재하는 button의 type 알맞게 지정하기
- `goal`, `repeatDDuDu` 데이터 패칭 공통 코드 함수로 분리
- `repeatDDuDu` 개별 데이터 패칭 query문 추가