### PR TITLE
[Fix] 배포 후 BottomSheet 영역 클릭 안되는 문제 수정

### DIFF
--- a/src/app/_components/client/BottomSheet/components/BottomPortal/BottomPortal.tsx
+++ b/src/app/_components/client/BottomSheet/components/BottomPortal/BottomPortal.tsx
@@ -34,7 +34,12 @@ const BottomPortal = ({ isShow, children, onClose }: BottomPortalProps) => {
   return createPortal(
     <>
       <div className="fixed top-0 w-screen h-screen max-w-[60rem] bg-transparent" />
-      <div ref={bottomSheetRef}>{children}</div>
+      <div
+        className="relative z-[501]"
+        ref={bottomSheetRef}
+      >
+        {children}
+      </div>
     </>,
     BottomElement,
   );


### PR DESCRIPTION
## 📝 설명
#76 

**배포 후 BottomSheet 영역 클릭 안되는 문제 수정**
<!-- PR에 대한 설명입니다. -->

## ✅ PR 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [ ] 새로운 기능 추가
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 파일 혹은 폴더명 수정 / 삭제
- [x] 기타

## 💻 작업 내용
- BottomSheet가 열릴 때 다른 요소 클릭을 방지하기 위해 투명색 배경을 뒤에 깔았는데, 해당 요소가 우선순위로 잡혀서 발생하는 문제로 예상됩니다.
- z-index를 통한 우선순위 조정 필요합니다.
