### PR TITLE
[Refactor] 목표 생성 페이지 (임시 저장 기능 수정)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,8 +19,7 @@
     "@typescript-eslint/ban-ts-comment": [
       "error",
       {
-        "ts-ignore": "never",
-        "ts-expect-error": "allow-with-description"
+        "ts-ignore": "allow-with-description"
       }
     ],
     "prettier/prettier": [

--- a/src/app/(route)/goal/editor/components/GoalEditor/hooks/useTempData/useTempData.tsx
+++ b/src/app/(route)/goal/editor/components/GoalEditor/hooks/useTempData/useTempData.tsx
@@ -32,7 +32,13 @@ const useTempData = ({ goalId, goalEditorData, openModal }: UseTempDataProps) =>
     repeatDDuDu: [...repeatDDuDu],
   });
 
+  const isHydrated = useGoalFormStore.persist.hasHydrated();
+
   useEffect(() => {
+    if (!isHydrated) {
+      return;
+    }
+
     if (isLoad) {
       initialize(tempData);
       setIsLoadTempData(true);
@@ -64,7 +70,7 @@ const useTempData = ({ goalId, goalEditorData, openModal }: UseTempDataProps) =>
     }
 
     /* eslint-disable react-hooks/exhaustive-deps */
-  }, []);
+  }, [isHydrated]);
 
   const handleLoadTempData = (isComplete: boolean) => {
     if (!isComplete) {

--- a/src/app/_store/useGoalFormStore/useGoalFormStore.ts
+++ b/src/app/_store/useGoalFormStore/useGoalFormStore.ts
@@ -1,6 +1,7 @@
 import { GoalPrivacyType, RepeatDdudusType } from "@/app/_types/response/goal/goal";
 
 import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
 
 export interface UseGoalFormStoreState {
   type: "CREATE" | "EDIT";
@@ -10,6 +11,8 @@ export interface UseGoalFormStoreState {
   goalPrivacy: GoalPrivacyType;
   color: string;
   repeatDDuDu: RepeatDdudusType[];
+  hasHydrated: boolean;
+  setHasHydrated: (hasHydrated: boolean) => void;
   setIsLoad: (isLoad: boolean) => void;
   setIsEditing: (isEditing: boolean) => void;
   setGoalText: (goalText: string) => void;
@@ -29,26 +32,9 @@ export interface UseGoalFormStoreProps {
   repeatDDuDu: RepeatDdudusType[];
 }
 
-const useGoalFormStore = create<UseGoalFormStoreState>((set) => ({
-  type: "CREATE",
-  isLoad: false,
-  isEditing: false,
-  goalText: "",
-  goalPrivacy: "PUBLIC",
-  color: "#1D1D1B",
-  repeatDDuDu: [],
-  setIsLoad: (isLoad) => set({ isLoad }),
-  setIsEditing: (isEditing) => set({ isEditing }),
-  setGoalText: (goalText) => set({ goalText }),
-  setGoalPrivacy: (goalPrivacy) => set({ goalPrivacy }),
-  setColor: (color) => set({ color }),
-  setRepeatDDuDu: (repeatDDuDu) => set({ repeatDDuDu }),
-  setAddRepeatDDuDu: (repeatDDuDu) =>
-    set((state) => ({ repeatDDuDu: [...state.repeatDDuDu, repeatDDuDu] })),
-  initialize: ({ type, goalText, goalPrivacy, color, repeatDDuDu }) =>
-    set({ type, goalText, goalPrivacy, color, repeatDDuDu }),
-  reset: () =>
-    set({
+const useGoalFormStore = create(
+  persist<UseGoalFormStoreState>(
+    (set) => ({
       type: "CREATE",
       isLoad: false,
       isEditing: false,
@@ -56,7 +42,37 @@ const useGoalFormStore = create<UseGoalFormStoreState>((set) => ({
       goalPrivacy: "PUBLIC",
       color: "#1D1D1B",
       repeatDDuDu: [],
+      hasHydrated: false,
+      setHasHydrated: (hasHydrated) => set({ hasHydrated }),
+      setIsLoad: (isLoad) => set({ isLoad }),
+      setIsEditing: (isEditing) => set({ isEditing }),
+      setGoalText: (goalText) => set({ goalText }),
+      setGoalPrivacy: (goalPrivacy) => set({ goalPrivacy }),
+      setColor: (color) => set({ color }),
+      setRepeatDDuDu: (repeatDDuDu) => set({ repeatDDuDu }),
+      setAddRepeatDDuDu: (repeatDDuDu) =>
+        set((state) => ({ repeatDDuDu: [...state.repeatDDuDu, repeatDDuDu] })),
+      initialize: ({ type, goalText, goalPrivacy, color, repeatDDuDu }) =>
+        set({ type, goalText, goalPrivacy, color, repeatDDuDu }),
+      reset: () =>
+        set({
+          type: "CREATE",
+          isLoad: false,
+          isEditing: false,
+          goalText: "",
+          goalPrivacy: "PUBLIC",
+          color: "#1D1D1B",
+          repeatDDuDu: [],
+        }),
     }),
-}));
+    {
+      name: "temp-data",
+      storage: createJSONStorage(() => sessionStorage),
+      onRehydrateStorage: () => (state) => {
+        state?.setHasHydrated(true);
+      },
+    },
+  ),
+);
 
 export default useGoalFormStore;


### PR DESCRIPTION
## 📝 설명
#84 
**목표 생성 페이지 (임시 저장 기능 수정)**
<!-- PR에 대한 설명입니다. -->

## ✅ PR 유형

<!--
	팀원이 어떤 작업을 하였는지 쉽게 알아볼 수 있게 도와주는 부분입니다.
-->

- [ ] 새로운 기능 추가
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드 리팩토링
- [ ] 파일 혹은 폴더명 수정 / 삭제
- [ ] 기타

## 💻 작업 내용
- 목표 생성 페이지에서 목표 생성 도중에 **페이지를 이탈**하거나 **새로고침한 경우**에도 **데이터를 임시 저장**하도록 했습니다.
- 기존에는 `전역 상태`로 데이터를 관리하고 페이지를 이탈하고 다시 목표 생성 페이지에 접근한 경우에만 임시 저장 데이터를 불러왔지만, **실수로 페이지를 새로고침하는 상황도 발생할 수 있기 때문**에 `전역 상태`에서 **`sessionStorage`로 데이터 저장을 변경**했습니다.
- `localStorage`를 **사용하지 않은 이유는 임시 저장되는 데이터가 페이지가 닫힌 후 다시 접근했는데도 데이터를 기억하는 것은 정상적인 흐름이 아니라고 판단**했습니다.
